### PR TITLE
Adapt ARD video link extraction regexp to support arrays of stream URLs.

### DIFF
--- a/mediathek/ard.py
+++ b/mediathek/ard.py
@@ -70,7 +70,7 @@ class ARDMediathek(Mediathek):
     self.pageSelectString = "&mcontent%s=page.%s"
     self.regex_DetermineSelectedPage = re.compile("&mcontents{0,1}=page.(\d+)");
     
-    self.regex_videoLinks = re.compile("\"_quality\":(\d).*?\"_stream\":\"(.*?)\"");
+    self.regex_videoLinks = re.compile("\"_quality\":(\d).*?\"_stream\":\[?\"(.*?)\"");
     self.regex_pictureLink = re.compile("_previewImage\":\"(.*?)\"");
     
     


### PR DESCRIPTION
ARD mediathek may return an array of URLs for the _stream key. In this
case, we extract the first URL in the array.

This fixes a bug where not all available qualities for a given programme
were extracted or qualities were misassociated.

See [videoPage.txt](https://github.com/raptor2101/Mediathek/files/214715/videoPage.txt) where qualities 1 and 2 have arrays.
