### PR TITLE
Limit each menu to either VideoLinks OR CategoryLinks

### DIFF
--- a/mediathek/ard.py
+++ b/mediathek/ard.py
@@ -122,7 +122,10 @@ class ARDMediathek(Mediathek):
       
   def extractElements(self,mainPage):
     videoElements = list(self.regex_VideoPageLink.finditer(mainPage));
-    linkElements = list(self.regex_CategoryPageLink.finditer(mainPage));
+    if len(videoElements) == 0:
+      linkElements = list(self.regex_CategoryPageLink.finditer(mainPage));
+    else:
+      linkElements = []
     
     counter = len(videoElements) + len(linkElements);
     for element in linkElements:


### PR DESCRIPTION
This is one approach to solve #79 

By stopping the search for links if VideoLinks are found, the category doesn't reappear in it's submenu. Additionally it improves performance.

This change however makes it impossible for a submenu to contain videos and subcategories at the same time. I didn't find a case where this would be desired, but it has to be considered. Maybe there is a more elegant way, so feel free to reject the PR.