### PR TITLE
Remove locally stored state

### DIFF
--- a/default.py
+++ b/default.py
@@ -16,14 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 
-import urllib,xbmc,os,xbmcaddon
+import urllib,xbmc,os
 from simplexbmc import SimpleXbmcGui
 from mediathek.factory import MediathekFactory
 __plugin__ = "mediathek"
 
-settings = xbmcaddon.Addon(id='plugin.video.mediathek');
-
-gui = SimpleXbmcGui(settings);
+gui = SimpleXbmcGui();
 
 def get_params():
   paramDict = {}
@@ -43,10 +41,6 @@ def get_params():
 params = get_params();
 mediathekName = params.get("type", "")
 action=params.get("action", "")
-
-DIR_HOME = xbmc.translatePath(settings.getAddonInfo("profile"))
-if not os.path.exists(DIR_HOME):
-  os.mkdir(DIR_HOME);
 
 gui.log("Quality: %s"%gui.quality);
 gui.log("argv[0]: %s"%sys.argv[0]);
@@ -96,9 +90,9 @@ else:
     else:
       gui.back();
   elif(action == "openJsonPath"):
+    link = urllib.unquote_plus(params.get("link", ""))
     path = params.get("path", "0");
-    callhash = params.get("callhash", "0");
-    mediathek.buildJsonMenu(path,callhash,0)
+    mediathek.buildJsonMenu(link,path,0)
   elif(action == "openJsonLink"):
     link = urllib.unquote_plus(params.get("link", ""));
     mediathek.playVideoFromJsonLink(link);

--- a/mediathek/zdf.py
+++ b/mediathek/zdf.py
@@ -42,7 +42,6 @@ class ZDFMediathek(Mediathek):
   def buildPageMenu(self, link, initCount):
     self.gui.log("buildPageMenu: "+link);
     jsonObject = json.loads(self.loadPage(link));
-    callhash = self.gui.storeJsonFile(jsonObject);
     
     if("stage" in jsonObject):
       for stageObject in jsonObject["stage"]:
@@ -51,12 +50,12 @@ class ZDFMediathek(Mediathek):
     
     if("cluster" in jsonObject):
       for counter, clusterObject in enumerate(jsonObject["cluster"]):
-        if clusterObject["type"].startswith("teaser") and "name" in clusterObject:
+        if "teaser" in clusterObject and "name" in clusterObject:
           path = "cluster.%d.teaser"%(counter)
-          self.gui.buildJsonLink(self,clusterObject["name"],path,callhash,counter)
+          self.gui.buildJsonLink(self,clusterObject["name"],link,path,len(clusterObject["teaser"]))
       
-  def buildJsonMenu(self, path,callhash, initCount):
-    jsonObject=self.gui.loadJsonFile(callhash);
+  def buildJsonMenu(self, link, path, initCount):
+    jsonObject=json.loads(self.loadPage(link))
     jsonObject=self.walkJson(path,jsonObject);
    
     categoriePages=[];

--- a/mediathek/zdf.py
+++ b/mediathek/zdf.py
@@ -44,19 +44,16 @@ class ZDFMediathek(Mediathek):
     jsonObject = json.loads(self.loadPage(link));
     callhash = self.gui.storeJsonFile(jsonObject);
     
-    counter=0;
-    
     if("stage" in jsonObject):
       for stageObject in jsonObject["stage"]:
         if(stageObject["type"]=="video"):
-          self.buildVideoLink(stageObject,counter);
+          self.buildVideoLink(stageObject);
     
     if("cluster" in jsonObject):
-      for clusterObject in jsonObject["cluster"]:
-        if clusterObject["type"].startswith("teaser"):
+      for counter, clusterObject in enumerate(jsonObject["cluster"]):
+        if clusterObject["type"].startswith("teaser") and "name" in clusterObject:
           path = "cluster.%d.teaser"%(counter)
           self.gui.buildJsonLink(self,clusterObject["name"],path,callhash,counter)
-        counter=counter+1;
       
   def buildJsonMenu(self, path,callhash, initCount):
     jsonObject=self.gui.loadJsonFile(callhash);
@@ -88,10 +85,10 @@ class ZDFMediathek(Mediathek):
     
     
     for videoObject in videoObjects:
-      self.buildVideoLink(videoObject,counter);
+      self.buildVideoLink(videoObject);
       
       
-  def buildVideoLink(self,videoObject,counter):
+  def buildVideoLink(self,videoObject):
     title=videoObject["headline"];
     subTitle=videoObject["titel"];
     description=videoObject["beschreibung"];
@@ -100,19 +97,19 @@ class ZDFMediathek(Mediathek):
       if int(width)<=840:
         imageLink=imageObject["url"];
     if("formitaeten" in videoObject):
-      links = self.extractLinks(jsonObject);
-      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,description,links,True),self,counter);
+      links = self.extractLinks(videoObject);
+      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,description,links,True),self,1);
     else:
       link = videoObject["url"];
-      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,description,link,"JsonLink"),self,counter);
+      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,description,link,"JsonLink"),self,1);
     
   def playVideoFromJsonLink(self,link):
     jsonObject = json.loads(self.loadPage(link));
-    links = self.extractLinks(jsonObject);
+    links = self.extractLinks(jsonObject["document"]);
     self.gui.play(links);
   def extractLinks(self,jsonObject):
     links={};
-    for formitaete in jsonObject["document"]["formitaeten"]:
+    for formitaete in jsonObject["formitaeten"]:
       url = formitaete["url"];
       quality = formitaete["quality"];
       hd = formitaete["hd"];

--- a/simplexbmc.py
+++ b/simplexbmc.py
@@ -17,8 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 import xbmc, xbmcgui, xbmcplugin,xbmcaddon, sys, urllib, os, time, re 
 from html import transformHtmlCodes
-import json
-import hashlib
 
 regex_findLink = re.compile("mms://[^\"]*wmv");
 
@@ -28,16 +26,12 @@ settings = xbmcaddon.Addon(id='plugin.video.mediathek')
 translation = settings.getLocalizedString
 
 class SimpleXbmcGui(object):
-  def __init__(self,settings):
+  def __init__(self):
     self.settings = xbmcaddon.Addon(id='plugin.video.mediathek');
     self.quality = int(xbmcplugin.getSetting(int(sys.argv[1]), "quality" ));
     self.preferedStreamTyp = int(xbmcplugin.getSetting(int(sys.argv[1]), "preferedStreamType"));
     
     self.log("quality: %s"%(self.quality));
-    
-    self.plugin_profile_dir = xbmc.translatePath(settings.getAddonInfo("profile"))
-    if not os.path.exists(self.plugin_profile_dir):
-      os.mkdir(self.plugin_profile_dir);
     
   def log(self, msg):
     if type(msg) not in (str, unicode):
@@ -108,24 +102,10 @@ class SimpleXbmcGui(object):
     url = "%s?type=%s&action=openMenu&path=%s" % (sys.argv[0],mediathek.name(), menuObject.path)
     xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=listItem,isFolder=True,totalItems = objectCount)
 
-  def storeJsonFile(self,jsonObject):
-    hashGenerator = hashlib.md5();
-    hashGenerator.update(sys.argv[2]);
-    callhash = hashGenerator.hexdigest();
-    storedJsonFile = os.path.join(self.plugin_profile_dir,"%s.json"%callhash);
-    output = open(storedJsonFile, 'wb');
-    json.dump(jsonObject,output);
-    return callhash;
-  
-  def loadJsonFile(self,callhash):
-    storedJsonFile = os.path.join(self.plugin_profile_dir,"%s.json"%callhash);
-    input = open(storedJsonFile,"rb");
-    return json.load(input);
-
-  def buildJsonLink(self,mediathek,title,jsonPath,callhash,objectCount):
+  def buildJsonLink(self,mediathek,title,link,jsonPath,objectCount):
     listItem=xbmcgui.ListItem(title, iconImage="DefaultFolder.png")
     
-    url = "%s?type=%s&action=openJsonPath&path=%s&callhash=%s" % (sys.argv[0],mediathek.name(), jsonPath,callhash)
+    url = "%s?type=%s&action=openJsonPath&link=%s&path=%s" % (sys.argv[0],mediathek.name(), urllib.quote_plus(link), jsonPath)
     xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=listItem,isFolder=True,totalItems = objectCount)
 
   def listAvaibleMediathekes(self, mediathekNames):

--- a/simplexbmc.py
+++ b/simplexbmc.py
@@ -75,7 +75,7 @@ class SimpleXbmcGui(object):
         xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=listItem,isFolder=False,totalItems = objectCount)
       else:
         self.log(displayObject.title);
-        link = self.extractLink(links);
+        link = self.extractLink(displayObject.link);
         
         if(type(link).__name__ == "ComplexLink"):
           self.log("PlayPath:"+ link.playPath);

--- a/simplexbmc.py
+++ b/simplexbmc.py
@@ -64,8 +64,9 @@ class SimpleXbmcGui(object):
         link = displayObject.link[0]
         
         url = "%s?type=%s&action=openPlayList&link=%s" % (sys.argv[0],mediathek.name(), urllib.quote_plus(link.basePath))
-        listItem.setProperty('IsPlayable', 'true');
-        xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=listItem,isFolder=False,totalItems = objectCount)
+        
+        self.log(url);
+        xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=listItem,isFolder=True,totalItems = objectCount)
       elif(displayObject.isPlayable == "JsonLink"):
         link = displayObject.link
         


### PR DESCRIPTION
Hi @raptor2101, regarding #85 you are completely correct that the JSON files should not be downloaded before a programme is selected. This speeds up directory display tremendously.

However, I really dislike storing state on the server even if it helps to save a second download time. I have done some experiments without storing any state locally and I think the plugin is still very responsive.

I have also fixed a crash 37f6df1 as well as some minor bugs b351bcb.

I am quite sure that ORF playlists are broken by 8b2aedb, please review my submission 55e6e2a.