### PR TITLE
Fix exception by skipping video items that are missing a "teaserBild".

### DIFF
--- a/mediathek/zdf.py
+++ b/mediathek/zdf.py
@@ -89,7 +89,9 @@ class ZDFMediathek(Mediathek):
     for entry in jsonObject:
       if entry["type"] == "brand":
         categoriePages.append(entry);
-      if entry["type"] == "video" and len(videoObjects) < 50:
+      if entry["type"] == "video" and \
+         "teaserBild" in entry and \
+         len(videoObjects) < 50:
         videoObjects.append(entry);  
     
     self.gui.log("CategoriePages: %d"%len(categoriePages));


### PR DESCRIPTION
When this occasionally occurs (as of today,
https://zdf-cdn.live.cellular.de/mediathekV2/document/die-kuechenschlacht-106)
such entries appear to be duplicates of others. At the time of writing,
cluster[1].teaser[2] is a duplicate of cluster[1].teaser[1] and
cluster[1].teaser[3] is a duplicate of cluster[1].teaser[4].